### PR TITLE
Latest recommended changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ ssh user@host
 ### Pre-requisities:
 1. JAVA Setup should be completed and JAVA_HOME should be set in the ~/.bashrc file (environment variable).
 2. Make sure the nodes are set for password-less SSH both ways(master->slaves).
-3. Since we use the environment variables a lot in our scripts, make sure to comment out the portion following this statement in your ~/.bashrc , 
-`If not running interactively, don't do anything`. Update .bashrc
+3. Since we use the environment variables a lot in our scripts, make sure to comment/delete out the portion following this statement in your ~/.bashrc , `If not running interactively, don't do anything`. 
 
  Delete/comment the following check.
   ```
@@ -36,7 +35,7 @@ ssh user@host
          *) return;;
    esac
   ```
-4. Same username/useraccount should be need on `master` and `slaves` nodes for multinode installation.
+4. Same username/useraccount should be needed on `master` and `slaves` nodes for multinode installation.
 
 ### Installations:
 
@@ -53,7 +52,7 @@ ssh user@host
    1. To configure `hadoop-cluster-utils`, run `./autogen.sh` which will create `config` with appropriate field values.
    2. User can enter SLAVE hostnames (if more than one, use comma seperated) interactively while running `./autogen.sh` file.
    3. Default `Spark-2.0.1` and `Hadoop-2.7.1` version available for installation. 
-   4. User can edit default port values, `spark` and `hadoop` versions in config
+   4. User can edit default port values, `spark` and `hadoop` versions in config file.
    5. Before executing `./setup.sh` file, user can verify or edit `config` 
    6. Once setup script completed,source `~/.bashrc` file to export updated hadoop and spark environment variables for current login session. 
    

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ ssh user@host
   
 * Configuration
 
-   1. To configure `hadoop-cluster-utils`, run `./autogen.sh` which will create `config.sh` with appropriate field values.
-   2. User can enter SLAVEIPs (if more than one, use comma seperated) interactively while running `./autogen.sh` file.
+   1. To configure `hadoop-cluster-utils`, run `./autogen.sh` which will create `config` with appropriate field values.
+   2. User can enter SLAVE hostnames (if more than one, use comma seperated) interactively while running `./autogen.sh` file.
    3. Default `Spark-2.0.1` and `Hadoop-2.7.1` version available for installation. 
-   4. User can edit default port values, `spark` and `hadoop` versions in config.sh
-   5. Before executing `./setup.sh` file, user can verify or edit `config.sh` 
+   4. User can edit default port values, `spark` and `hadoop` versions in config
+   5. Before executing `./setup.sh` file, user can verify or edit `config` 
    6. Once setup script completed,source `~/.bashrc` file to export updated hadoop and spark environment variables for current login session. 
    
 * Ensure that the following java process is running in master. If not, check the log files

--- a/autogen.sh
+++ b/autogen.sh
@@ -3,16 +3,16 @@
 
 # Creating new config
 echo -e '# Default hdfs configuration properties' > config
-echo -e 'HADOOP_TMP_DIR='${HOME}'/hadoop_tmp/app-hadoop' >> config
+echo -e 'HADOOP_TMP_DIR='${HOME}'/hdfs_dir/app-hadoop' >> config 
 echo -e 'REPLICATION_VALUE=3' >> config
-echo -e 'NAMENODE_DIR='${HOME}'/hadoop_tmp/hdfs-meta' >> config
-echo -e 'DATANODE_DIR='${HOME}'/hadoop_tmp/hdfs-data' >> config
+echo -e 'NAMENODE_DIR='${HOME}'/hdfs_dir/hdfs-meta' >> config
+echo -e 'DATANODE_DIR='${HOME}'/hdfs_dir/hdfs-data' >> config
 
 echo -en '# Master Details\n' >> config
 MASTER=`hostname`
 echo -en 'MASTER='$MASTER'\n\n' >> config
 
-echo -en 'Please enter slave hostname detail in format slave1_hostname,slave2_hostname \n'
+echo -en 'Please enter slave hostname details in format slave1_hostname,slave2_hostname \n'
 read SLAVE_HOSTNAME
 
 echo -en '# Using these format to save SLAVE Details: slave1IP,slave1cpu,slave1memory....\n' >> config
@@ -70,17 +70,17 @@ echo -en 'DATANODE_HTTP_ADDRESS=50075\n' >> config
 echo -en 'DATANODE_IPC_ADDRESS=50020\n\n' >> config
 
 echo -en 'MAPREDUCE_JOBHISTORY_ADDRESS=10020\n' >> config
-echo -en 'MAPREDUCE_JOBHISTORY_ADMIN_ADDRESS=10039\n' >> config 
-echo -en 'MAPREDUCE_JOBHISTORY_WEBAPP_ADDRESS=19883\n\n' >> config
+echo -en 'MAPREDUCE_JOBHISTORY_ADMIN_ADDRESS=10033\n' >> config 
+echo -en 'MAPREDUCE_JOBHISTORY_WEBAPP_ADDRESS=19888\n\n' >> config
 
-echo -en 'RESOURCEMANAGER_SCHEDULER_ADDRESS=8034\n' >> config
-echo -en 'RESOURCEMANAGER_RESOURCE_TRACKER_ADDRESS=8039\n' >> config
-echo -en 'RESOURCEMANAGER_ADDRESS=8038\n' >> config
+echo -en 'RESOURCEMANAGER_SCHEDULER_ADDRESS=8030\n' >> config
+echo -en 'RESOURCEMANAGER_RESOURCE_TRACKER_ADDRESS=8031\n' >> config
+echo -en 'RESOURCEMANAGER_ADDRESS=8032\n' >> config
 echo -en 'RESOURCEMANAGER_ADMIN_ADDRESS=8033\n' >> config
-echo -en 'RESOURCEMANAGER_WEBAPP_ADDRESS=8089\n\n' >> config
+echo -en 'RESOURCEMANAGER_WEBAPP_ADDRESS=8088\n\n' >> config
 
-echo -en 'NODEMANAGER_LOCALIZER_ADDRESS=8043\n' >> config
-echo -en 'NODEMANAGER_WEBAPP_ADDRESS=8045\n\n' >> config
+echo -en 'NODEMANAGER_LOCALIZER_ADDRESS=8040\n' >> config
+echo -en 'NODEMANAGER_WEBAPP_ADDRESS=8042\n\n' >> config
 echo -en 'SPARKHISTORY_HTTP_ADDRESS=18080\n\n' >> config
 
 echo -e 'Please check configuration (config file) once before run (setup.sh file).'

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,90 +1,90 @@
 #!/bin/bash -l
 
 
-# Creating new config.sh
-echo -en '# Default hdfs configuration properties\n' > config.sh
-echo -en 'HADOOP_TMP_DIR=/tmp/'"${USER}"'/app-hadoop\n' >> config.sh
-echo -en 'REPLICATION_VALUE=3\n' >> config.sh
-echo -en 'NAMENODE_DIR=/tmp/'"${USER}"'/hdfs-meta\n' >> config.sh
-echo -en 'DATANODE_DIR=/tmp/'"${USER}"'/hdfs-data\n\n' >> config.sh
+# Creating new config
+echo -e '# Default hdfs configuration properties' > config
+echo -e 'HADOOP_TMP_DIR='${HOME}'/hadoop_tmp/app-hadoop' >> config
+echo -e 'REPLICATION_VALUE=3' >> config
+echo -e 'NAMENODE_DIR='${HOME}'/hadoop_tmp/hdfs-meta' >> config
+echo -e 'DATANODE_DIR='${HOME}'/hadoop_tmp/hdfs-data' >> config
 
-echo -en '# Master Details\n' >> config.sh
-MASTER=`ifconfig | grep "inet" |head -1 | awk {'print $2'} | cut -f2 -d ":"`
-echo -en 'MASTER='$MASTER'\n\n' >> config.sh
+echo -en '# Master Details\n' >> config
+MASTER=`hostname`
+echo -en 'MASTER='$MASTER'\n\n' >> config
 
-echo -en 'Please enter slave IP detail in format slave1IP,slave2IP \n'
-read SLAVEIP
+echo -en 'Please enter slave hostname detail in format slave1_hostname,slave2_hostname \n'
+read SLAVE_HOSTNAME
 
-echo -en '# Using these format to save SLAVE Details: slave1IP,slave1cpu,slave1memory....\n' >> config.sh
+echo -en '# Using these format to save SLAVE Details: slave1IP,slave1cpu,slave1memory....\n' >> config
 echo -e
 
 j=0
-for i in `echo $SLAVEIP |tr ',' ' '`
+for i in `echo $SLAVE_HOSTNAME |tr ',' ' '`
 do
-slaveip=$(ssh $i /sbin/ifconfig | grep "inet" |head -1 | awk {'print $2'} | cut -f2 -d ":")
-echo -en 'Collecting memory details from SLAVE machine '$slaveip' \n'
-freememory=$(ssh $slaveip free -m | awk '{print $4}'| head -2 | tail -1)
+slavehost=$(ssh $i hostname)
+echo -en 'Collecting memory details from SLAVE machine '$slavehost' \n'
+freememory=$(ssh $slavehost free -m | awk '{print $4}'| head -2 | tail -1)
 memorypercent=$(awk "BEGIN { pc=80*$freememory/100; i=int(pc); print (pc-i<0.5)?i:i+1 }")
-ncpu=$(ssh $slaveip nproc --all)
+ncpu=$(ssh $slavehost nproc --all)
 if [ $j -eq 0 ]
 then
-SLAVE=`echo ''$slaveip','$ncpu','$memorypercent''`
+SLAVE=`echo ''$slavehost','$ncpu','$memorypercent''`
 else
-SLAVE=`echo ''$SLAVE'%'$slaveip','$ncpu','$memorypercent''`
+SLAVE=`echo ''$SLAVE'%'$slavehost','$ncpu','$memorypercent''`
 fi
 ((j=j+1))
 done
 
-echo -en 'SLAVES='$SLAVE'\n\n' >> config.sh
+echo -en 'SLAVES='$SLAVE'\n\n' >> config
 
-echo -en '#Node Manager properties (Default yarn cpu and memory value for all nodes)\n' >> config.sh	 
-echo -en 'YARN_SCHEDULER_MIN_ALLOCATION_MB=128\n' >> config.sh				 
-echo -en 'YARN_SCHEDULER_MIN_ALLOCATION_VCORES=1\n\n' >> config.sh
+echo -en '#Node Manager properties (Default yarn cpu and memory value for all nodes)\n' >> config	 
+echo -en 'YARN_SCHEDULER_MIN_ALLOCATION_MB=128\n' >> config				 
+echo -en 'YARN_SCHEDULER_MIN_ALLOCATION_VCORES=1\n\n' >> config
 echo -e
 echo -en 'Default Spark version : 2.0.1\n'
 sparkver="2.0.1"
 echo -en 'Default hadoop version : 2.7.1\n'	
 hadoopver="2.7.1"
 
-echo -en '#Hadoop and Spark versions and setup zip download urls\n' >> config.sh
+echo -en '#Hadoop and Spark versions and setup zip download urls\n' >> config
 echo -e
-echo -en 'sparkver='"$sparkver"'\n' >> config.sh
-echo -en 'hadoopver='"$hadoopver"'\n\n' >> config.sh
+echo -en 'sparkver='"$sparkver"'\n' >> config
+echo -en 'hadoopver='"$hadoopver"'\n\n' >> config
 
 HADOOP_URL="http://www-us.apache.org/dist/hadoop/common/hadoop-${hadoopver}/hadoop-${hadoopver}.tar.gz"
 SPARK_URL="http://www-us.apache.org/dist/spark/spark-${sparkver}/spark-${sparkver}-bin-hadoop${hadoopver:0:3}.tgz"
 
-echo -en 'SPARK_URL='$SPARK_URL'\n' >> config.sh
-echo -en 'HADOOP_URL='$HADOOP_URL'\n\n' >> config.sh
+echo -en 'SPARK_URL='$SPARK_URL'\n' >> config
+echo -en 'HADOOP_URL='$HADOOP_URL'\n\n' >> config
 
 
-echo -en '# Default port values\n' >> config.sh
+echo -en '# Default port values\n' >> config
 
-echo -en 'NAMENODE_PORT=9000\n' >> config.sh
-echo -en 'NAMENODE_HTTP_ADDRESS=50070\n' >> config.sh
-echo -en 'NAMENODE_SECONDARY_HTTP_ADDRESS=50090\n' >> config.sh
-echo -en 'NAMENODE_SECONDARY_HTTPS_ADDRESS=50091\n\n' >> config.sh
+echo -en 'NAMENODE_PORT=9000\n' >> config
+echo -en 'NAMENODE_HTTP_ADDRESS=50070\n' >> config
+echo -en 'NAMENODE_SECONDARY_HTTP_ADDRESS=50090\n' >> config
+echo -en 'NAMENODE_SECONDARY_HTTPS_ADDRESS=50091\n\n' >> config
 
-echo -en 'DATANODE_ADDRESS=50010\n' >> config.sh
-echo -en 'DATANODE_HTTP_ADDRESS=50075\n' >> config.sh
-echo -en 'DATANODE_IPC_ADDRESS=50020\n\n' >> config.sh
+echo -en 'DATANODE_ADDRESS=50010\n' >> config
+echo -en 'DATANODE_HTTP_ADDRESS=50075\n' >> config
+echo -en 'DATANODE_IPC_ADDRESS=50020\n\n' >> config
 
-echo -en 'MAPREDUCE_JOBHISTORY_ADDRESS=10020\n' >> config.sh
-echo -en 'MAPREDUCE_JOBHISTORY_ADMIN_ADDRESS=10039\n' >> config.sh 
-echo -en 'MAPREDUCE_JOBHISTORY_WEBAPP_ADDRESS=19883\n\n' >> config.sh
+echo -en 'MAPREDUCE_JOBHISTORY_ADDRESS=10020\n' >> config
+echo -en 'MAPREDUCE_JOBHISTORY_ADMIN_ADDRESS=10039\n' >> config 
+echo -en 'MAPREDUCE_JOBHISTORY_WEBAPP_ADDRESS=19883\n\n' >> config
 
-echo -en 'RESOURCEMANAGER_SCHEDULER_ADDRESS=8034\n' >> config.sh
-echo -en 'RESOURCEMANAGER_RESOURCE_TRACKER_ADDRESS=8039\n' >> config.sh
-echo -en 'RESOURCEMANAGER_ADDRESS=8038\n' >> config.sh
-echo -en 'RESOURCEMANAGER_ADMIN_ADDRESS=8033\n' >> config.sh
-echo -en 'RESOURCEMANAGER_WEBAPP_ADDRESS=8089\n\n' >> config.sh
+echo -en 'RESOURCEMANAGER_SCHEDULER_ADDRESS=8034\n' >> config
+echo -en 'RESOURCEMANAGER_RESOURCE_TRACKER_ADDRESS=8039\n' >> config
+echo -en 'RESOURCEMANAGER_ADDRESS=8038\n' >> config
+echo -en 'RESOURCEMANAGER_ADMIN_ADDRESS=8033\n' >> config
+echo -en 'RESOURCEMANAGER_WEBAPP_ADDRESS=8089\n\n' >> config
 
-echo -en 'NODEMANAGER_LOCALIZER_ADDRESS=8043\n' >> config.sh
-echo -en 'NODEMANAGER_WEBAPP_ADDRESS=8045\n\n' >> config.sh
-echo -en 'SPARKHISTORY_HTTP_ADDRESS=18080\n\n' >> config.sh
+echo -en 'NODEMANAGER_LOCALIZER_ADDRESS=8043\n' >> config
+echo -en 'NODEMANAGER_WEBAPP_ADDRESS=8045\n\n' >> config
+echo -en 'SPARKHISTORY_HTTP_ADDRESS=18080\n\n' >> config
 
-echo -e 'Please check configuration (config.sh file) once before run (setup.sh file).'
-echo -e 'You can modify hadoop or spark versions in config.sh file'
+echo -e 'Please check configuration (config file) once before run (setup.sh file).'
+echo -e 'You can modify hadoop or spark versions in config file'
 echo -e
-chmod +x config.sh
+chmod +x config
 

--- a/setup.sh
+++ b/setup.sh
@@ -19,31 +19,7 @@ fi
 
 log=`pwd`/logs/hadoop_cluster_utils_$current_time.log
 echo -e | tee -a $log
-grep '^export JAVA_HOME' $HOME/.bashrc &>>/dev/null
-if [[ $? -eq 0 ]]
-then
-    echo JAVA_HOME found on MASTER, java executable in $JAVA_HOME | tee $log
-    echo "---------------------------------------------" | tee -a $log
-else
-    echo "JAVA_HOME not found in your environment, please set the JAVA_HOME variable in your environment then continue to run this script." | tee -a $log
-    exit 1 
-fi
 
-grep '#case $- in' $HOME/.bashrc &>>/dev/null
- if [ $? -ne 0 ]
-then
-    grep 'case $- in' $HOME/.bashrc &>>/dev/null
-	if [ $? -eq 0 ]
-	then 
-        echo 'Prerequisite not completed on Master. Please comment below lines in .bashrc file , also make sure same on slave machines' | tee -a $log
-        echo "# If not running interactively, don't do anything" | tee -a $log
-        echo "case \$- in" | tee -a $log
-        echo "*i*) ;;" | tee -a $log
-        echo "*) return;;" | tee -a $log
-        echo "esac" | tee -a $log
-	    exit 1
-	fi	
-fi
 
 ##Checking if wget and curl installed or not, and getting installed if not
 
@@ -60,6 +36,8 @@ if [ ! -x /usr/bin/curl ] ; then
 else
    echo "curl is already installed on Master" | tee -a $log
 fi
+
+echo "---------------------------------------------" | tee -a $log	
 
 ## Validation for config file
 
@@ -82,6 +60,60 @@ then
           fi
       fi
     done
+	
+	#Logic to create server list 
+    cat ${CURDIR}/config | grep SLAVES | grep -v "^#" | tr "%" "\n" | grep "$MASTER" &>>/dev/null
+    if [ $? -eq 0 ]
+    then
+	    #if master is also used as data machine 
+        SERVERS=$SLAVES
+    else
+	    ## Getting details for Master machine
+        freememory_master="$(free -m | awk '{print $4}'| head -2 | tail -1)"
+        memorypercent_master=$(awk "BEGIN { pc=80*${freememory_master}/100; i=int(pc); print (pc-i<0.5)?i:i+1 }")
+        ncpu_master="$(nproc --all)"
+        MASTER_DETAILS=''$MASTER','$ncpu_master','$memorypercent_master''
+        SERVERS=`echo ''$MASTER_DETAILS'%'$SLAVES''`
+    fi
+	
+	#Check for JAVA_HOME in bashrc of all nodes
+	for i in `echo $SERVERS |cut -d "=" -f2 | tr "%" "\n" | cut -d "," -f1`
+	do
+		JAVA=$(ssh $i "grep '^export JAVA_HOME' $HOME/.bashrc | cut -f2 -d "="") 2>/dev/null
+		if [[ $? -eq 0 ]]
+		then
+			echo -e 'JAVA_HOME found in bashrc of '$i' and java executable in '$JAVA'' | tee -a $log
+		else
+			echo -e 'JAVA_HOME not found in bashrc of '$i', please set the JAVA_HOME variable then continue to run this script.' | tee -a $log
+			exit 1 
+		fi
+	done
+    
+    echo "---------------------------------------------" | tee -a $log	
+    
+	#Checking for prerequisite on master
+	
+	for i in `echo $SERVERS |cut -d "=" -f2 | tr "%" "\n" | cut -d "," -f1`
+	do
+		ssh $i "grep '^#case \$- in' $HOME/.bashrc" &>/dev/null
+		if [ $? -ne 0 ]
+		then
+			ssh $i "grep '^case \$- in' $HOME/.bashrc" &>/dev/null
+			if [ $? -eq 0 ]
+			then 
+				echo 'Prerequisite not completed on '$i'. Please comment below lines in .bashrc file.' | tee -a $log
+				echo "# If not running interactively, don't do anything" | tee -a $log
+				echo "case \$- in" | tee -a $log
+				echo "*i*) ;;" | tee -a $log
+				echo "*) return;;" | tee -a $log
+				echo "esac" | tee -a $log
+				exit 1
+			fi	
+		fi
+	
+	done 
+
+
 
     ## Validation for hadoop port instances
 
@@ -112,40 +144,22 @@ then
     ## Adding slave machine names to slave file
     cat ${CURDIR}/config | grep SLAVES | grep -v "^#" |cut -d "=" -f2 | tr "%" "\n" | cut -d "," -f1  >${CURDIR}/conf/slaves 
 
-
     
-    SLAVES=`cat ${CURDIR}/config | grep SLAVES | grep -v "^#" |cut -d "=" -f2`
-    
-    cat ${CURDIR}/config | grep SLAVES | grep -v "^#" | tr "%" "\n" | grep "$MASTER" &>>/dev/null
-    if [ $? -eq 0 ]
-    then
-	    #if master is also used as data machine 
-        SERVERS=$SLAVES
-    else
-	    ## Getting details for Master machine
- 
-        freememory_master="$(free -m | awk '{print $4}'| head -2 | tail -1)"
-        memorypercent_master=$(awk "BEGIN { pc=80*${freememory_master}/100; i=int(pc); print (pc-i<0.5)?i:i+1 }")
-        ncpu_master="$(nproc --all)"
-        MASTER_DETAILS=''$MASTER','$ncpu_master','$memorypercent_master''
-        SERVERS=`echo ''$MASTER_DETAILS'%'$SLAVES''`
-    fi
-     
-    ## Validation for Slaves IPs
-    echo -e "${ul}Validation for slave IPs${nul}" | tee -a $log
-    while IFS= read -r ip; do
-         if ping -q -c2 "$ip" &>/dev/null;
+    ## Validation for Slaves hostnames/IPs
+    echo -e "${ul}Validation for slave Hostnames${nul}" | tee -a $log
+    while IFS= read -r host; do
+         if ping -q -c2 "$host" &>/dev/null;
          then
-             echo "$ip is Pingable" | tee -a $log
+             echo "$host is Pingable" | tee -a $log
          else
-             echo "$ip Not Pingable" | tee -a $log
-             echo 'Please check your config file. '$ip' is not pingalbe. \n' | tee -a $log
+             echo "$host Not Pingable" | tee -a $log
+             echo 'Please check your config file. '$host' is not pingalbe. \n' | tee -a $log
          exit 1
          fi
     done <${CURDIR}/conf/slaves
 
   
-    ## Download and install hadoop For Master machine installation
+    ## Download hadoop on Master machine 
   
     echo "---------------------------------------------" | tee -a $log
     echo "${ul}Downloading and installing hadoop...${nul}" | tee -a $log
@@ -158,7 +172,7 @@ then
             echo 'Hadoop file Downloading on Master- '$MASTER'' | tee -a $log
 	        wget $HADOOP_URL | tee -a $log
         else
-            echo "This URL Not Exist. Please check your hadoop version then continue to run this script." | tee -a $log
+            echo "This URL does not exist. Please check your hadoop version then continue to run this script." | tee -a $log
             exit 1
         fi 
     fi	
@@ -176,7 +190,7 @@ then
 		ssh $i '[ -d '${WORKDIR}/hadoop-${hadoopver}' ]' &>>/dev/null
 		if [ $? -eq 0 ]
 		then 
-		echo 'Deleting already existing hadoop folder-'hadoop-${hadoopver}' from '$i' '| tee -a $log
+		echo 'Deleting existing hadoop folder "'hadoop-${hadoopver}'" from '$i' '| tee -a $log
 		ssh $i "rm -rf ${WORKDIR}/hadoop-${hadoopver}" &>>/dev/null
 		fi
 		
@@ -224,8 +238,6 @@ then
 	
 	## Configuration changes in hadoop-clusterfor Core-site,hdfs-site and mapred-site xml
 	
-    echo 'Updating configuration properties in hadoop-cluster CURDIR for Core-site,hdfs-site and mapred-site xml ' | tee -a $log
-
     if [ ! -f ${CURDIR}/conf/core-site.xml ];
     then
 	    #Copying xml templates for editing 
@@ -259,9 +271,6 @@ then
   
     fi  
       
-   
-    echo "---------------------------------------------" | tee -a $log
-
     ## yarn-site.xml configuration properties and hadoop-env.sh file updates for all machines
 
   	for i in `echo $SERVERS  |cut -d "=" -f2 | tr "%" "\n" `
@@ -269,9 +278,9 @@ then
 	 
       memorypercent=`echo $i| cut -d "," -f3`	
 	  ncpu=`echo $i| cut -d "," -f2`
-	  slaveip=`echo $i| cut -d "," -f1`
+	  slavehost=`echo $i| cut -d "," -f1`
 		 
-	  echo 'Updating configuration properties for yarn-sites and hadoop.env.sh for '$slaveip'' | tee -a $log
+	  echo 'Updating configuration properties for all xml files and hadoop.env.sh on '$slavehost'' | tee -a $log
 		 
 	  cp ${CURDIR}/conf/yarn-site.xml.template ${CURDIR}/conf/yarn-site.xml
 	  
@@ -291,16 +300,17 @@ then
       sed -i 's|NODEMANAGER_WEBAPP_ADDRESS|'"$NODEMANAGER_WEBAPP_ADDRESS"'|g' ${CURDIR}/conf/yarn-site.xml
 		 
 		 
-	  scp ${CURDIR}/conf/*site.xml @$slaveip:$HADOOP_HOME/etc/hadoop | tee -a $log
+	  scp ${CURDIR}/conf/*site.xml @$slavehost:$HADOOP_HOME/etc/hadoop | tee -a $log
 		 
 	  ## Updating java version in hadoop-env.sh file on all machines
 		 
-	  JAVA_HOME_SLAVE=$(ssh $slaveip 'grep JAVA_HOME ~/.bashrc | grep -v "PATH" | cut -d"=" -f2')
-	  echo "sed -i 's|"\${JAVA_HOME}"|"${JAVA_HOME_SLAVE}"|g' $HADOOP_HOME/etc/hadoop/hadoop-env.sh" | ssh $slaveip bash
-      echo "---------------------------------------------" | tee -a $log
-	  
+	  JAVA_HOME_SLAVE=$(ssh $slavehost 'grep JAVA_HOME ~/.bashrc | grep -v "PATH" | cut -d"=" -f2')
+	  echo "sed -i 's|"\${JAVA_HOME}"|"${JAVA_HOME_SLAVE}"|g' $HADOOP_HOME/etc/hadoop/hadoop-env.sh" | ssh $slavehost bash
+      	  
     done	 
 	rm -rf ${CURDIR}/conf/*site.xml
+	
+	echo "---------------------------------------------" | tee -a $log
  	
     ##Updating the slave file on master 
  
@@ -344,7 +354,7 @@ do
 	ssh $i '[ -d '${WORKDIR}/spark-${sparkver}-bin-hadoop${hadoopver:0:3}' ]' &>>/dev/null
 	if [ $? -eq 0 ]
 		then 
-		echo 'Deleting already existing spark folder-'spark-${sparkver}-bin-hadoop${hadoopver:0:3}'  from '$i' '| tee -a $log
+		echo 'Deleting existing spark folder "'spark-${sparkver}-bin-hadoop${hadoopver:0:3}'"  from '$i' '| tee -a $log
 		ssh $i "rm -rf ${WORKDIR}/spark-${sparkver}-bin-hadoop${hadoopver:0:3}" &>>/dev/null
 	fi
 	
@@ -392,17 +402,17 @@ if [ $? -ne 0 ];
 then
     echo "#StartSparkconf" >> $SPARK_HOME/conf/spark-defaults.conf
     echo "spark.eventLog.enabled   true" >> $SPARK_HOME/conf/spark-defaults.conf
-    echo 'spark.eventLog.dir       '${HOME}'/hadoop_tmp/spark-events' >> $SPARK_HOME/conf/spark-defaults.conf 
+    echo 'spark.eventLog.dir       '${HOME}'/hdfs_dir/spark-events' >> $SPARK_HOME/conf/spark-defaults.conf 
     echo "spark.eventLog.compress  true" >> $SPARK_HOME/conf/spark-defaults.conf
-    echo 'spark.history.fs.logDirectory   '${HOME}'/hadoop_tmp/spark-events-history' >> $SPARK_HOME/conf/spark-defaults.conf
+    echo 'spark.history.fs.logDirectory   '${HOME}'/hdfs_dir/spark-events-history' >> $SPARK_HOME/conf/spark-defaults.conf
     echo "#StopSparkconf">> $SPARK_HOME/conf/spark-defaults.conf
 else
     sed -i '/#StartSparkconf/,/#StopSparkconf/ d' $SPARK_HOME/conf/spark-defaults.conf
     echo "#StartSparkconf" >> $SPARK_HOME/conf/spark-defaults.conf 
     echo "spark.eventLog.enabled   true" >> $SPARK_HOME/conf/spark-defaults.conf
-    echo 'spark.eventLog.dir       '${HOME}'/hadoop_tmp/spark-events' >> $SPARK_HOME/conf/spark-defaults.conf
+    echo 'spark.eventLog.dir       '${HOME}'/hdfs_dir/spark-events' >> $SPARK_HOME/conf/spark-defaults.conf
     echo "spark.eventLog.compress  true" >> $SPARK_HOME/conf/spark-defaults.conf
-    echo 'spark.history.fs.logDirectory   '${HOME}'/hadoop_tmp/spark-events-history' >> $SPARK_HOME/conf/spark-defaults.conf
+    echo 'spark.history.fs.logDirectory   '${HOME}'/hdfs_dir/spark-events-history' >> $SPARK_HOME/conf/spark-defaults.conf
     echo "#StopSparkconf">> $SPARK_HOME/conf/spark-defaults.conf
 fi
 
@@ -424,16 +434,16 @@ then
      AN "mkdir -p $HADOOP_TMP_DIR" &>/dev/null
      AN "mkdir -p $NAMENODE_DIR" &>/dev/null
      AN "mkdir -p $DATANODE_DIR" &>/dev/null
-     AN "mkdir -p '${HOME}'/hadoop_tmp/spark-events" &>/dev/null
-     AN "mkdir -p '${HOME}'/hadoop_tmp/spark-events-history" &>/dev/null
+     AN "mkdir -p '${HOME}'/hdfs_dir/spark-events" &>/dev/null
+     AN "mkdir -p '${HOME}'/hdfs_dir/spark-events-history" &>/dev/null
      echo "Finished creating directories"
 else 
-     AN "rm -rf '${HOME}'/hadoop_tmp/*" &>/dev/null
+     AN "rm -rf '${HOME}'/hdfs_dir/*" &>/dev/null
 	 AN "mkdir -p $HADOOP_TMP_DIR" &>/dev/null
      AN "mkdir -p $NAMENODE_DIR" &>/dev/null
      AN "mkdir -p $DATANODE_DIR" &>/dev/null
-     AN "mkdir -p '${HOME}'/hadoop_tmp/spark-events" &>/dev/null
-     AN "mkdir -p '${HOME}'/hadoop_tmp/spark-events-history" &>/dev/null
+     AN "mkdir -p '${HOME}'/hdfs_dir/spark-events" &>/dev/null
+     AN "mkdir -p '${HOME}'/hdfs_dir/spark-events-history" &>/dev/null
      echo "Finished creating directories"
 fi        
 
@@ -449,7 +459,7 @@ $CURDIR/utils/checkall.sh | tee -a $log
 
 echo -e | tee -a $log
 echo "${ul}Web URL link${nul}" | tee -a $log
-echo "HDFS web address : http://"$MASTER":"$NAMENODE_HTTP_ADDRESS"" | tee -a $log
+echo "HDFS web address : http://"$MASTER":"$NAMENODE_HTTP_ADDRESS"" | tee -a $log 
 echo "Resource Manager : http://"$MASTER":"$RESOURCEMANAGER_WEBAPP_ADDRESS"/cluster" | tee -a $log
 echo "SPARK history server : http://"$MASTER":"$SPARKHISTORY_HTTP_ADDRESS"" | tee -a $log
 echo -e | tee -a $log
@@ -476,9 +486,9 @@ grep -r 'Pi is roughly' ${log}
 if [ $? -eq 0 ];
 then
    echo -e 'Spark services running.\n' | tee -a $log
-   echo 'Please check log file '$log' for more details.'
+   echo -e 'Please check log file '$log' for more details.\n'
 else
    echo -e 'Expected output not found.\n' | tee -a $log
-   echo 'Please check log file '$log' for more details'
+   echo -e 'Please check log file '$log' for more details. \n'
 fi
-echo 'Please execute "source ~/.bashrc" to export updated hadoop and spark environment variables in your current login session'
+echo -e 'Please execute "source ~/.bashrc" to export updated hadoop and spark environment variables in your current login session. \n'

--- a/setup.sh
+++ b/setup.sh
@@ -79,14 +79,16 @@ then
 	#Check for JAVA_HOME in bashrc of all machines
 	for i in `echo $SERVERS |cut -d "=" -f2 | tr "%" "\n" | cut -d "," -f1`
 	do
-		JAVA=$(ssh $i "grep '^export JAVA_HOME' $HOME/.bashrc | cut -f2 -d "="") 2>/dev/null
+		ssh $i 'grep "^export JAVA_HOME" /home/testuser/.bashrc' &>/dev/null
 		if [[ $? -eq 0 ]]
 		then
+            JAVA=$(ssh $i "grep '^export JAVA_HOME' $HOME/.bashrc | cut -f2 -d "="") 2>/dev/null
 			echo -e 'JAVA_HOME found in bashrc of '$i' and java executable in '$JAVA'' | tee -a $log
 		else
 			echo -e 'JAVA_HOME not found in bashrc of '$i', please set the JAVA_HOME variable then continue to run this script.' | tee -a $log
 			exit 1 
 		fi
+		
 	done
     
     echo "---------------------------------------------" | tee -a $log	

--- a/setup.sh
+++ b/setup.sh
@@ -76,7 +76,7 @@ then
         SERVERS=`echo ''$MASTER_DETAILS'%'$SLAVES''`
     fi
 	
-	#Check for JAVA_HOME in bashrc of all nodes
+	#Check for JAVA_HOME in bashrc of all machines
 	for i in `echo $SERVERS |cut -d "=" -f2 | tr "%" "\n" | cut -d "," -f1`
 	do
 		JAVA=$(ssh $i "grep '^export JAVA_HOME' $HOME/.bashrc | cut -f2 -d "="") 2>/dev/null
@@ -91,7 +91,7 @@ then
     
     echo "---------------------------------------------" | tee -a $log	
     
-	#Checking for prerequisite on master
+	#Checking for other prerequisite
 	
 	for i in `echo $SERVERS |cut -d "=" -f2 | tr "%" "\n" | cut -d "," -f1`
 	do
@@ -190,17 +190,15 @@ then
 		ssh $i '[ -d '${WORKDIR}/hadoop-${hadoopver}' ]' &>>/dev/null
 		if [ $? -eq 0 ]
 		then 
-		echo 'Deleting existing hadoop folder "'hadoop-${hadoopver}'" from '$i' '| tee -a $log
-		ssh $i "rm -rf ${WORKDIR}/hadoop-${hadoopver}" &>>/dev/null
+		 echo 'Deleting existing hadoop folder "'hadoop-${hadoopver}'" from '$i' '| tee -a $log
+		 ssh $i "rm -rf ${WORKDIR}/hadoop-${hadoopver}" &>>/dev/null
 		fi
 		
-        echo 'Unzipping Hadoop setup file on '$i'' | tee -a $log	  
-	    ssh $i "tar xf hadoop-${hadoopver}.tar.gz --gzip" 
+         echo 'Unzipping Hadoop setup file on '$i'' | tee -a $log	  
+	     ssh $i "tar xf hadoop-${hadoopver}.tar.gz --gzip" 
 	 
-        echo 'Updating hadoop variables on '$i'' | tee -a $log
+         echo 'Updating hadoop variables on '$i'' | tee -a $log
 		 
-	     export HADOOP_HOME="${WORKDIR}"/hadoop-${hadoopver}
-
 	     export HADOOP_HOME="${WORKDIR}"/hadoop-${hadoopver}
 	     echo "#StartHadoopEnv"> tmp_b
          echo "export CURDIR="${CURDIR}"" >> tmp_b
@@ -321,6 +319,17 @@ else
     exit 1
 fi  
 
+##exporting hadoop variables for current script session on master
+export HADOOP_HOME=${WORKDIR}/hadoop-${hadoopver}
+export HADOOP_PREFIX=$HADOOP_HOME
+export HADOOP_MAPRED_HOME=$HADOOP_HOME
+export HADOOP_COMMON_HOME=$HADOOP_HOME
+export HADOOP_HDFS_HOME=$HADOOP_HOME
+export YARN_HOME=$HADOOP_HOME
+export HADOOP_CONF_DIR=$HADOOP_HOME/etc/hadoop
+export YARN_CONF_DIR=$HADOOP_HOME/etc/hadoop
+export PATH=$HADOOP_HOME/bin:$PATH
+
 ##Spark installation
 
 echo -e "${ul}Downloading and installing Spark...${nul}\n" | tee -a $log
@@ -384,6 +393,10 @@ do
     echo "---------------------------------------------" | tee -a $log			
 done
 rm -rf tmp_b
+
+##Exporting spark variables for current script session on master
+export SPARK_HOME=${WORKDIR}/spark-${sparkver}-bin-hadoop${hadoopver:0:3}
+export PATH=$SPARK_HOME/bin:$PATH
 
 
 ## updating Slave file for Spark folder


### PR DESCRIPTION
`Script is updated with below changes`

1. Renamed config.sh to just config
2. autogen.sh  now asks users to enter hostnames, instead of IP for both master and slaves. Also, internally using hostname instead of IPs.
3. While extracting hadoop or spark files, removing existing  hadoop and spark directories.
4. Added a check to ensure JAVA_HOME is set in bashrc for all machines (master+slaves)
5. Displaying a message to execute "source ~/.bashrc" at the end of setup.sh.
6. Modified spark log properties to display only errors.
7. Changed hdfs & spark directory locations under home directory e.g. /home/testuser/hdfs_dir/hdfs-meta , /home/testuser/hdfs_dir/hdfs-data
8. Exporting Hadoop and spark variables inside script to counter case where sourcing bashrc does not work, as we have noticed this on some runs.
