### PR TITLE
replication value changes

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -4,7 +4,7 @@
 # Creating new config
 echo -e '# Default hdfs configuration properties' > config
 echo -e 'HADOOP_TMP_DIR='${HOME}'/hdfs_dir/app-hadoop' >> config 
-echo -e 'REPLICATION_VALUE=3' >> config
+#echo -e 'REPLICATION_VALUE=3' >> config
 echo -e 'NAMENODE_DIR='${HOME}'/hdfs_dir/hdfs-meta' >> config
 echo -e 'DATANODE_DIR='${HOME}'/hdfs_dir/hdfs-data' >> config
 
@@ -34,6 +34,20 @@ SLAVE=`echo ''$SLAVE'%'$slavehost','$ncpu','$memorypercent''`
 fi
 ((j=j+1))
 done
+
+##logic to set replication value=3 only if no of datanodes>3
+if [ $j -eq 1 ]
+then
+	echo -e 'REPLICATION_VALUE=1' >> config
+elif [ $j -eq 2 ]
+then
+	echo -e 'REPLICATION_VALUE=1' >> config
+elif [ $j -eq 3 ]
+then
+	echo -e 'REPLICATION_VALUE=2' >> config
+else 
+	echo -e 'REPLICATION_VALUE=3' >> config
+fi
 
 echo -en 'SLAVES='$SLAVE'\n\n' >> config
 


### PR DESCRIPTION
Changes made in autogen.sh for setting replication count default =3 only if no of datanodes > 3 else =1 in case of no of datanodes 1 & 2 and =2 in case of 3.
We found this changes required for running tpcds benchmark in 2 node cluster.
 